### PR TITLE
Add CSS rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+## v1.0.0 - 06/13/2017
+### Added
+- stylelint rules based on `stylelint-config-standard`
+- stylelint tests using Jest
+- README, explaining how install and use this package.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+stylelint-config-css
+====================
+
+The ComparaOnline [stylelint](https://stylelint.io) shareable configuration for CSS projects.
+
+# Installation
+
+First, you need stylelint, if it isn't installed yet...
+
+```
+$ npm install --save-dev stylelint
+```
+
+Then,
+
+```
+$ npm install --save-dev @comparaonline/stylelint-config-css
+```
+
+# Usage
+
+Add this package into the `extends` section of your `.stylelintrc.js` file.
+
+```js
+{
+  extends: '@comparaonline/stylelint-config-css'
+}
+```
+
+Now you can execute `stylelint` in a npm script, as example:
+
+```json
+"scripts": {
+  "lint:styles": "stylelint './app/**/*.scss'"
+}
+```

--- a/__tests__/css.js
+++ b/__tests__/css.js
@@ -1,0 +1,142 @@
+'use strict'
+
+const config = require('../');
+const stylelint = require('stylelint');
+
+const invalidPropertyNoVendorPrefix = (
+`.selector-1 {
+  -webkit-transition: all 4s ease;
+}
+`);
+
+const validPropertyNoVendorPrefix = (
+`.selector-1 {
+  transition: all 4s ease;
+}
+`);
+
+const invalidSelectorNoVendorPrefix = (
+`input::-moz-placeholder {
+  color: transparent;
+}
+`);
+
+const validSelectorNoVendorPrefix = (
+`input::placeholder {
+  color: transparent;
+}
+`);
+
+const invalidValueNoVendorPrefix = (
+`a {
+  background: -webkit-linear-gradient(135deg, red, blue);
+}
+`);
+
+const validValueNoVendorPrefix = (
+`a {
+  background: linear-gradient(135deg, red, blue);
+}
+`);
+
+const tooLongLine = (
+`div.a-super-super-long-selector-with-a-children > div.children-with-after::after {
+  color: blue;
+}
+`
+);
+
+const validCompoundSelectorOrder = `
+.selector > div { color: blue; }
+`
+const invalidCompoundSelectorOrder = `
+.selector > div > span > span > { color: blue; }
+`;
+
+let result;
+
+describe('vendor prefix', () => {
+  describe('property-no-vendor-prefix', () => {
+    it("fails", () => {
+      result = stylelint.lint({ code: invalidPropertyNoVendorPrefix, config });
+      return result.then(data => expect(data.errored).toBe(true));
+    });
+
+    it("passes", () => {
+      result = stylelint.lint({ code: validPropertyNoVendorPrefix, config });
+      return result.then(data => expect(data.errored).toBe(false));
+    });
+  });
+
+  describe('selector-no-vendor-prefix', () => {
+    it("fails", () => {
+      result = stylelint.lint({ code: invalidSelectorNoVendorPrefix, config });
+      return result.then(data => expect(data.errored).toBe(true));
+    });
+
+    it("passes", () => {
+      result = stylelint.lint({ code: validSelectorNoVendorPrefix, config });
+      return result.then(data => expect(data.errored).toBe(false));
+    });
+  });
+
+  describe('value-no-vendor-prefix', () => {
+    it("fails", () => {
+      result = stylelint.lint({ code: invalidValueNoVendorPrefix, config });
+      return result.then(data => expect(data.errored).toBe(true));
+    });
+
+    it("passes", () => {
+      result = stylelint.lint({ code: validValueNoVendorPrefix, config });
+      return result.then(data => expect(data.errored).toBe(false));
+    });
+  });
+});
+
+const invalidAlphabeticalOrder = (
+`.selector {
+  transition: all 4s ease;
+  color: blue;
+}
+`);
+
+const validAlphabeticalOrder = (
+`.selector {
+  color: blue;
+  transition: all 4s ease;
+}
+`);
+
+describe('order/properties-alphabetical-order', () => {
+  it("fails", () => {
+    result = stylelint.lint({ code: invalidAlphabeticalOrder, config });
+    return result.then(data => expect(data.errored).toBe(true));
+  });
+
+  it("passes", () => {
+    result = stylelint.lint({ code: validAlphabeticalOrder, config });
+    return result.then(data => expect(data.errored).toBe(false));
+  });
+});
+
+
+describe('max-line-length', () => {
+  it("fails", () => {
+    result = stylelint.lint({ code: tooLongLine, config });
+    return result.then(data => expect(data.errored).toBe(true));
+  });
+});
+
+describe('selector-max-compound-selectors', () => {
+  it("fails", () => {
+    result = stylelint.lint({ code: invalidCompoundSelectorOrder, config });
+    return result.then(data => expect(data.errored).toBe(true));
+  });
+
+  it("passes", () => {
+    result = stylelint.lint({ code: validCompoundSelectorOrder, config });
+    return result.then(data => expect(data.errored).toBe(false));
+  });
+})
+
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,37 @@
+"use strict"
+
+ module.exports = {
+  "extends": "stylelint-config-standard",
+  "plugins": [
+    "stylelint-order"
+  ],
+
+  "rules": {
+    "rule-empty-line-before": [
+      "always-multi-line",
+      {
+        "except": ["first-nested"],
+        "ignore": ["after-comment"]
+      }
+    ],
+
+    "color-named": [
+      "always-where-possible",
+      { "ignore": ["inside-function"] }
+    ],
+
+    "at-rule-no-vendor-prefix": true,
+    "declaration-no-important": true,
+    "font-weight-notation": "numeric",
+    "max-line-length": 80,
+    "max-nesting-depth": 2,
+    "media-feature-name-no-vendor-prefix": true,
+    "order/properties-alphabetical-order": true,
+    "property-no-vendor-prefix": true,
+    "selector-max-compound-selectors": 2,
+    "selector-no-id": true,
+    "selector-no-vendor-prefix": true,
+    "selector-pseudo-element-colon-notation": "double",
+    "value-no-vendor-prefix": true
+  }
+ };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@comparaonline/stylelint-config-css",
+  "version": "1.0.0",
+  "description": "ComparaOnline stylelint configuration for CSS projects",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/comparaonline/stylelint-config-css"
+  },
+  "keywords": [
+    "stylelint",
+    "stylelint-config",
+    "comparaonline"
+  ],
+  "author": "Esteban Martini <emartini@comparaonline.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/comparaonline/stylelint-config-css/issues"
+  },
+  "homepage": "https://github.com/comparaonline/stylelint-config-css#readme",
+  "peerDependencies": {
+    "stylelint": "^7.11.0"
+  },
+  "devDependencies": {
+    "jest": "^20.0.0",
+    "stylelint": "^7.11.0"
+  },
+  "dependencies": {
+    "stylelint-config-standard": "^16.0.0",
+    "stylelint-order": "^0.5.0"
+  }
+}


### PR DESCRIPTION
Relevant rules.
- Extends from [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard)
- No prefixes on selectors, attributes and media features, this means you may need an autoprefixer tool
- No id selectors
- Line max width is 80 chars
- Max selector deep of 2. IE: `.parent > .child {}`
- Set the [pseudo-element-colon-notation](https://stylelint.io/user-guide/rules/selector-pseudo-element-colon-notation/) to double colon. IE: `.element::after {}`
- properties has to be sort by ascending alphabetical order
- can't use `!important`
- prefer number notation for `font-weight`