### PR TITLE
Remove order plugin and simplify rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## v1.0.0 - 06/13/2017
+## v0.0.2 - 06/14/2017
+### Changed
+- removed `stylelint-order` plugin
+- removed `rule-empty-line-before`, it's already added in `stylelint-config-standard`
+- simplied `color-named` rule
+
+## v0.0.1 - 06/13/2017
 ### Added
 - stylelint rules based on `stylelint-config-standard`
 - stylelint tests using Jest
-- README, explaining how install and use this package.
+- README, explaining how install and use this package

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Now you can execute `stylelint` in a npm script, as example:
 
 ```json
 "scripts": {
-  "lint:styles": "stylelint './app/**/*.scss'"
+  "lint:styles": "stylelint './app/**/*.css'"
 }
 ```

--- a/__tests__/css.js
+++ b/__tests__/css.js
@@ -93,33 +93,6 @@ describe('vendor prefix', () => {
   });
 });
 
-const invalidAlphabeticalOrder = (
-`.selector {
-  transition: all 4s ease;
-  color: blue;
-}
-`);
-
-const validAlphabeticalOrder = (
-`.selector {
-  color: blue;
-  transition: all 4s ease;
-}
-`);
-
-describe('order/properties-alphabetical-order', () => {
-  it("fails", () => {
-    result = stylelint.lint({ code: invalidAlphabeticalOrder, config });
-    return result.then(data => expect(data.errored).toBe(true));
-  });
-
-  it("passes", () => {
-    result = stylelint.lint({ code: validAlphabeticalOrder, config });
-    return result.then(data => expect(data.errored).toBe(false));
-  });
-});
-
-
 describe('max-line-length', () => {
   it("fails", () => {
     result = stylelint.lint({ code: tooLongLine, config });

--- a/index.js
+++ b/index.js
@@ -2,31 +2,14 @@
 
  module.exports = {
   "extends": "stylelint-config-standard",
-  "plugins": [
-    "stylelint-order"
-  ],
-
   "rules": {
-    "rule-empty-line-before": [
-      "always-multi-line",
-      {
-        "except": ["first-nested"],
-        "ignore": ["after-comment"]
-      }
-    ],
-
-    "color-named": [
-      "always-where-possible",
-      { "ignore": ["inside-function"] }
-    ],
-
     "at-rule-no-vendor-prefix": true,
+    "color-named": "always-where-possible",
     "declaration-no-important": true,
     "font-weight-notation": "numeric",
     "max-line-length": 80,
     "max-nesting-depth": 2,
     "media-feature-name-no-vendor-prefix": true,
-    "order/properties-alphabetical-order": true,
     "property-no-vendor-prefix": true,
     "selector-max-compound-selectors": 2,
     "selector-no-id": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/stylelint-config-css",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "description": "ComparaOnline stylelint configuration for CSS projects",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,6 @@
     "stylelint": "^7.11.0"
   },
   "dependencies": {
-    "stylelint-config-standard": "^16.0.0",
-    "stylelint-order": "^0.5.0"
+    "stylelint-config-standard": "^16.0.0"
   }
 }


### PR DESCRIPTION
The `stylint-order` plugin requires to be customized by each project depending on how it is used, I prefer to delegate this configuration to each project.

As it's not a production ready project, the version was set to `0.0.2` instead of `1.1.0`. The previous published package was deleted from npm (sorry about that 🙈)